### PR TITLE
Adding a rudimentary Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM golang:1.9
+FROM golang:1.9-alpine
 
 EXPOSE 8080
 WORKDIR $GOPATH/src/github.com/Azure/mirrorcat
+
+RUN apk add --update git
 
 ADD . $GOPATH/src/github.com/Azure/mirrorcat
 RUN go get -u github.com/golang/dep/cmd/dep

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ FROM alpine
 RUN apk add --update git
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/Azure/mirrorcat/mirrorcat/mirrorcat .
+EXPOSE 8080
 ENTRYPOINT [ "./mirrorcat", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.9
+
+EXPOSE 8080
+WORKDIR $GOPATH/src/github.com/Azure/mirrorcat
+
+ADD . $GOPATH/src/github.com/Azure/mirrorcat
+RUN go get -u github.com/golang/dep/cmd/dep
+RUN dep ensure
+RUN go install ./mirrorcat/
+
+ENTRYPOINT ["mirrorcat", "start"]

--- a/mirrorcat/cmd/version.go
+++ b/mirrorcat/cmd/version.go
@@ -1,0 +1,57 @@
+// Copyright © 2017 Microsoft Corp and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+var commit string
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Prints information about the instance of MirrorCat that is running.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if commit == "" {
+			commit = "Unknown"
+		}
+		fmt.Println("Built from commit:", commit)
+		fmt.Println(runtime.Version(), runtime.GOOS)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/mirrorcat/main.go
+++ b/mirrorcat/main.go
@@ -16,6 +16,8 @@ package main
 
 import "github.com/Azure/mirrorcat/mirrorcat/cmd"
 
+var commit string
+
 func main() {
 	cmd.Execute()
 }


### PR DESCRIPTION
This docker file creates an Alpine-based container image, using Go 1.9.x to build and run the local copy of mirrorcat.