### PR TITLE
Reducing the size of the `clone` operation.

### DIFF
--- a/push.go
+++ b/push.go
@@ -101,7 +101,7 @@ func Push(ctx context.Context, original, mirror RemoteRef, depth int) (err error
 		return
 	}
 
-	cloner := exec.CommandContext(ctx, "git", "clone", original.Repository, cloneLoc)
+	cloner := exec.CommandContext(ctx, "git", "clone", "--branch", original.Ref, "--single-branch", "--", original.Repository, cloneLoc)
 	if depth > 0 {
 		clonerArgs := append([]string(nil), "--depth", fmt.Sprint(depth))
 		clonerArgs = append(clonerArgs, cloner.Args[2:]...)


### PR DESCRIPTION
Today, MirrorCat clones all of the objects in the original remote repository. This is pretty needless. This PR reduces the size of the clone just the branch that was touched by a Push Event.